### PR TITLE
feat: add stopEvent property to ROverlay

### DIFF
--- a/src/ROverlay.tsx
+++ b/src/ROverlay.tsx
@@ -39,6 +39,8 @@ export interface ROverlayProps extends PropsWithChildren<unknown> {
     autoPosition?: boolean;
     /** Called immediately on click */
     onClick?: (event: MouseEvent<HTMLDivElement>) => void;
+    /** Stop event propagation */
+    stopEvent?: boolean;
 }
 
 /**
@@ -62,7 +64,8 @@ export class ROverlayBase<P extends ROverlayProps> extends RlayersBase<P, Record
         this.ol = new Overlay({
             autoPan: props.autoPan,
             offset: props.offset,
-            positioning: props.positioning
+            positioning: props.positioning,
+            stopEvent: props.stopEvent
         });
         this.containerRef = React.createRef();
     }


### PR DESCRIPTION
Currently, the stopEvent property of ROverlay cannot be controlled and is always true. Also, if “pointer-events-none” is not specified in ROverlay, it will not work correctly when the map is moved or expanded on ROverlay. However, if “pointer-events-none” is removed, the onClick event will no longer fire.
Setting `stopEvent=false` solves the above problem.